### PR TITLE
fix(?) shellmenu init

### DIFF
--- a/ShellMenu.py
+++ b/ShellMenu.py
@@ -48,13 +48,13 @@ class ShellMenu(Menu):
                 pass
             time.sleep(1)
 
-    @command
     def use(self, agent_name: str) -> None:
         """
         Use shell
 
         Usage: shell
         """
+        self.selected = agent_name
         self.update_directory(agent_name)
 
     def update_directory(self, agent_name: str):

--- a/main.py
+++ b/main.py
@@ -95,7 +95,6 @@ class EmpireCli(object):
         if menu.init(**kwargs):
             self.current_menu = menu
             self.menu_history.append(menu)
-            self.current_menu.selected = kwargs['selected']
 
     def main(self):
         if empire_config.yaml.get('suppress-self-cert-warning', True):


### PR DESCRIPTION
* `change_menu` calls init with `kwargs`
* `init` checks if `kwargs` contains the `selected` key
* if it does, it calls `use`